### PR TITLE
add authority in PublicClientApplication

### DIFF
--- a/msal-java-webapp-sample/src/main/java/com/microsoft/azure/msalwebsample/AuthHelper.java
+++ b/msal-java-webapp-sample/src/main/java/com/microsoft/azure/msalwebsample/AuthHelper.java
@@ -153,11 +153,12 @@ class AuthHelper {
         httpResponse.sendRedirect(authorizationCodeUrl);
     }
 
-    String getAuthorizationCodeUrl(String claims, String scope, String registeredRedirectURL, String state, String nonce) {
+    String getAuthorizationCodeUrl(String claims, String scope, String registeredRedirectURL, String state, String nonce)
+            throws MalformedURLException {
 
         String updatedScopes = scope == null ? "" : scope;
 
-        PublicClientApplication pca = PublicClientApplication.builder(clientId).build();
+        PublicClientApplication pca = PublicClientApplication.builder(clientId).authority(authority).build();
 
         AuthorizationRequestUrlParameters parameters =
                 AuthorizationRequestUrlParameters


### PR DESCRIPTION
PublicClientApplication is not reading <authority> in application.properties, and will always use 'common' for tenantId:
![image](https://user-images.githubusercontent.com/17075863/95967499-e654a400-0e3e-11eb-8ec8-3283aa8f6ce8.png)
