### PR TITLE
Clarify some steps in the READMEs

### DIFF
--- a/msal-b2c-web-sample/README.md
+++ b/msal-b2c-web-sample/README.md
@@ -63,26 +63,24 @@ In the steps below, "ClientID" is the same as "Application ID" or "AppId".
 
 #### Configure the webapp
 
-1. Open the `resources/application.properties` file
-
+Open the `resources/application.properties` file
+1. Fill in your tenant and app registration information noted in registration step. 
    * Set the values of `b2c.tenant` and `b2c.host` with the name of the Azure AD B2C tenant that you created.
      For example, replace `fabrikamb2c` with `contoso`.
    * Set the value of `b2c.clientId` with the application ID that you recorded.
    * Replace the value of `b2c.secret` with the key that you recorded.
    * Replace the value of `b2c.redirectUri` with `https://localhost:8443/msal4jsample/secure/aad​`.
 
-In order to use https with localhost fill in server.ssl.key properties.  
-Use keytool utility (included in JRE) if you want to generate self-signed certificate.
+1. In order to use HTTPS on localhost, you need to set up a self-signed certificate. 
+ - This terminal command will use Java's keytool utility to create a keystore called `keystore.p12` in the current directory, which is secured using the password `password`, and will create a cert with an alias of `testCert` and add it to the keystore.
 
-```
-Example:  
-keytool -genkeypair -alias testCert -keyalg RSA -storetype PKCS12 -keystore keystore.p12 -storepass password
+`keytool -genkeypair -alias testCert -keyalg RSA -storetype PKCS12 -keystore keystore.p12 -storepass password`
 
-server.ssl.key-store-type=PKCS12  
-server.ssl.key-store=classpath:keystore.p12  
-server.ssl.key-store-password=password  
-server.ssl.key-alias=testCert
-```
+ - Once you have your keystore/certificate, add its info to the SSL keystore properties in `application.properties`.
+    - Replace `Enter_Key_Store_Here` with the path to the keystore.p12 file
+    - Replace `Enter_Key_Store_Password_Here` and `Enter_Key_Password_Here` with the password
+    - Replace `Enter_Key_Store_Type_Here` with the store type (PKCS12)
+    - Replace `Enter_Key_Alias_Here` with the cert's alias
 
 ### Step 5: Run the application
 

--- a/msal-java-webapp-sample/README.md
+++ b/msal-java-webapp-sample/README.md
@@ -101,23 +101,25 @@ As a first step you'll need to:
 
 ### Step 4:  Configure the sample to use your Azure AD tenant
 
-Open `application.properties` in the src/main/resources folder. Fill in with your tenant and app registration information noted in registration step. Replace *Enter_the_Tenant_Info_Here* with the **Tenant Id**, *Enter_the_Application_Id_here* with the **Application Id** and *Enter_the_Client_Secret_Here* with the **key value** noted.
+Open `application.properties` in the src/main/resources folder.
+1. Fill in your tenant and app registration information noted in registration step. 
+   - Replace `Enter_the_Tenant_Info_Here` with the **Tenant Id**
+   - Replace `Enter_the_Application_Id_here` with the **Application Id**
+   - Replace `Enter_the_Client_Secret_Here` with the **secret key value**
+   
+1. If you did not use the  default redirect URIs, then you'll have to update `aad.redirectUriSignin` and `aad.redirectUriGraph` as well with the registered redirect URIs.
+   - You can use any host and port number, but the path must stay the same (/msal4jsample/secure/aad and /msal4jsample/graph/me) as these are mapped to the controllers that will process the requests.
 
-If you did not use the  default redirect URIs, then you'll have to update `aad.redirectUriSignin` and `aad.redirectUriGraph` as well with the registered redirect URIs.
-> You can use any host and port number, but the path must stay the same (/msal4jsample/secure/aad and /msal4jsample/graph/me) as these are mapped to the controllers that will process the requests.
+1. In order to use HTTPS on localhost, you need to set up a self-signed certificate. 
+ - This terminal command will use Java's keytool utility to create a keystore called `keystore.p12` in the current directory, which is secured using the password `password`, and will create a cert with an alias of `testCert` and add it to the keystore.
 
-In order to use https with localhost fill in server.ssl.key properties.  
-Use keytool utility (included in JRE) if you want to generate self-signed certificate.
+`keytool -genkeypair -alias testCert -keyalg RSA -storetype PKCS12 -keystore keystore.p12 -storepass password`
 
-```
-Example:  
-keytool -genkeypair -alias testCert -keyalg RSA -storetype PKCS12 -keystore keystore.p12 -storepass password
-
-server.ssl.key-store-type=PKCS12
-server.ssl.key-store=classpath:keystore.p12
-server.ssl.key-store-password=password
-server.ssl.key-alias=testCert
-```
+ - Once you have your keystore/certificate, add its info to the SSL keystore properties in `application.properties`.
+    - Replace `Enter_Key_Store_Here` with the path to the keystore.p12 file
+    - Replace `Enter_Key_Store_Password_Here` and `Enter_Key_Password_Here` with the password
+    - Replace `Enter_Key_Store_Type_Here` with the store type (PKCS12)
+    - Replace `Enter_Key_Alias_Here` with the cert's alias
 
 ### Step 5: Run the application
 

--- a/spring-security-web-app/README.md
+++ b/spring-security-web-app/README.md
@@ -92,24 +92,27 @@ As a first step you'll need to:
 
    - Type a key description (for instance `app secret`),
    - Select a key duration of either **In 1 year**, **In 2 years**, or **Never Expires** as per your security concerns.
-   - The generated key value will be displayed when you click the **Add** button. Copy the generated value for use in the steps later.
-   - You'll need this key later in your code's configuration files. This key value will not be displayed again, and is not retrievable by any other means, so make sure to note it from the Azure portal before navigating to any other screen or blade.
+   - The generated key value will be displayed when you click the **Add** button. **Copy the generated value for use in the steps later**.
+     - You'll need this key later in your code's configuration files. This key value will not be displayed again, and is not retrievable by any other means, so make sure to note it from the Azure portal before navigating to any other screen or blade.
 
 ### Step 4:  Configure the sample to use your Azure AD tenant
 
-Open `application.properties` in the src/main/resources folder. Fill in with your tenant and app registration information noted in registration step. Replace *Enter_the_Tenant_Info_Here* with the **Tenant Id**, *Enter_the_Application_Id_here* with the **Application Id** and *Enter_the_Client_Secret_Here* with the **key value** noted.
+Open `application.properties` in the src/main/resources folder. 
+1. Fill in your tenant and app registration information noted in registration step. 
+   - Replace `Enter_the_Tenant_Info_Here` with the **Tenant Id**
+   - Replace `Enter_the_Application_Id_here` with the **Application Id**
+   - Replace `Enter_the_Client_Secret_Here` with the **secret key value**
 
-In order to use https with localhost fill in server.ssl.key properties.  
-Use keytool utility (included in JRE) if you want to generate self-signed certificate.
+1. In order to use HTTPS on localhost, you need to set up a self-signed certificate. 
+ - This terminal command will use Java's keytool utility to create a keystore called `keystore.p12` in the current directory, which is secured using the password `password`, and will create a cert with an alias of `testCert` and add it to the keystore.
 
-```
-keytool -genkeypair -alias testCert -keyalg RSA -storetype PKCS12 -keystore keystore.p12 -storepass password
+`keytool -genkeypair -alias testCert -keyalg RSA -storetype PKCS12 -keystore keystore.p12 -storepass password`
 
-server.ssl.key-store-type=PKCS12  
-server.ssl.key-store=classpath:keystore.p12  
-server.ssl.key-store-password=password  
-server.ssl.key-alias=testCert  
-```
+ - Once you have your keystore/certificate, add its info to the SSL keystore properties in `application.properties`.
+    - Replace `Enter_Key_Store_Here` with the path to the keystore.p12 file
+    - Replace `Enter_Key_Store_Password_Here` and `Enter_Key_Password_Here` with the password
+    - Replace `Enter_Key_Store_Type_Here` with the store type (PKCS12)
+    - Replace `Enter_Key_Alias_Here` with the cert's alias
 
 ### Step 5: Run the application
 


### PR DESCRIPTION
Clarifies the steps related to setting up the cert needed to run the samples on HTTPS, and configuring info in the `application.properties` file